### PR TITLE
prevent attribute enforcement during play mode

### DIFF
--- a/Editor/DisallowComponentClassAttributeEnforcer.cs
+++ b/Editor/DisallowComponentClassAttributeEnforcer.cs
@@ -20,6 +20,7 @@ namespace Ikonoclast.ClassAttributes.Editor
     {
         #region Fields
 
+        private static bool isSubscribed;
         private static bool enabled = false;
         private static Assembly[] assemblies;
         private static List<Type> typesWithAttribute;
@@ -83,6 +84,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         public DisallowComponentClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
             Utilities.Register(this);
 
             LoadConfigurations();
@@ -104,6 +107,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         ~DisallowComponentClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+
             Utilities.Unregister(this);
 
             Unsubscribe();
@@ -115,10 +120,15 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         private static void Subscribe()
         {
+            if (isSubscribed)
+                return;
+
             EditorSceneManager.sceneOpened += OnSceneOpened;
             Selection.selectionChanged += OnSelectionChanged;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement += OnRequestAttributeEnforcement;
+
+            isSubscribed = true;
         }
 
         private static void Unsubscribe()
@@ -127,6 +137,8 @@ namespace Ikonoclast.ClassAttributes.Editor
             Selection.selectionChanged -= OnSelectionChanged;
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement -= OnRequestAttributeEnforcement;
+
+            isSubscribed = false;
         }
 
         private static void LoadConfigurations()
@@ -205,6 +217,15 @@ namespace Ikonoclast.ClassAttributes.Editor
             if (enforceOnSceneChange)
             {
                 OnHierarchyChanged();
+            }
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            switch (playModeStateChange)
+            {
+                case PlayModeStateChange.EnteredEditMode: Subscribe(); break;
+                case PlayModeStateChange.EnteredPlayMode: Unsubscribe(); break;
             }
         }
 

--- a/Editor/RequireChildComponentClassAttributeEnforcer.cs
+++ b/Editor/RequireChildComponentClassAttributeEnforcer.cs
@@ -23,6 +23,7 @@ namespace Ikonoclast.ClassAttributes.Editor
     {
         #region Fields
 
+        private static bool isSubscribed;
         private static bool enabled = false;
         private static Assembly[] assemblies;
         private static List<Type> typesWithAttribute;
@@ -86,6 +87,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         public RequireChildComponentClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
             Utilities.Register(this);
 
             LoadConfigurations();
@@ -107,6 +110,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         ~RequireChildComponentClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+
             Utilities.Unregister(this);
 
             Unsubscribe();
@@ -118,10 +123,15 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         private static void Subscribe()
         {
+            if (isSubscribed)
+                return;
+
             EditorSceneManager.sceneOpened += OnSceneOpened;
             Selection.selectionChanged += OnSelectionChanged;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement += OnRequestAttributeEnforcement;
+
+            isSubscribed = true;
         }
 
         private static void Unsubscribe()
@@ -130,6 +140,8 @@ namespace Ikonoclast.ClassAttributes.Editor
             Selection.selectionChanged -= OnSelectionChanged;
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement -= OnRequestAttributeEnforcement;
+
+            isSubscribed = false;
         }
 
         private static void LoadConfigurations()
@@ -265,6 +277,15 @@ namespace Ikonoclast.ClassAttributes.Editor
             if (enforceOnSceneChange)
             {
                 OnHierarchyChanged();
+            }
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            switch (playModeStateChange)
+            {
+                case PlayModeStateChange.EnteredEditMode: Subscribe(); break;
+                case PlayModeStateChange.EnteredPlayMode: Unsubscribe(); break;
             }
         }
 

--- a/Editor/RequireLayerClassAttributeEnforcer.cs
+++ b/Editor/RequireLayerClassAttributeEnforcer.cs
@@ -22,6 +22,7 @@ namespace Ikonoclast.ClassAttributes.Editor
     {
         #region Fields
 
+        private static bool isSubscribed;
         private static bool enabled = false;
         private static Assembly[] assemblies;
         private static List<Type> typesWithAttribute;
@@ -85,6 +86,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         public RequireLayerClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
             Utilities.Register(this);
 
             LoadConfigurations();
@@ -106,6 +109,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         ~RequireLayerClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+
             Utilities.Unregister(this);
 
             Unsubscribe();
@@ -117,10 +122,15 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         private static void Subscribe()
         {
+            if (isSubscribed)
+                return;
+
             EditorSceneManager.sceneOpened += OnSceneOpened;
             Selection.selectionChanged += OnSelectionChanged;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement += OnRequestAttributeEnforcement;
+
+            isSubscribed = true;
         }
 
         private static void Unsubscribe()
@@ -129,6 +139,8 @@ namespace Ikonoclast.ClassAttributes.Editor
             Selection.selectionChanged -= OnSelectionChanged;
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement -= OnRequestAttributeEnforcement;
+
+            isSubscribed = false;
         }
 
         private static void LoadConfigurations()
@@ -274,6 +286,15 @@ namespace Ikonoclast.ClassAttributes.Editor
             if (enforceOnSceneChange)
             {
                 OnHierarchyChanged();
+            }
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            switch (playModeStateChange)
+            {
+                case PlayModeStateChange.EnteredEditMode: Subscribe(); break;
+                case PlayModeStateChange.EnteredPlayMode: Unsubscribe(); break;
             }
         }
 

--- a/Editor/RequireTagClassAttributeEnforcer.cs
+++ b/Editor/RequireTagClassAttributeEnforcer.cs
@@ -22,6 +22,7 @@ namespace Ikonoclast.ClassAttributes.Editor
     {
         #region Fields
 
+        private static bool isSubscribed;
         private static bool enabled = false;
         private static Assembly[] assemblies;
         private static List<Type> typesWithAttribute;
@@ -85,6 +86,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         public RequireTagClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
             Utilities.Register(this);
 
             LoadConfigurations();
@@ -106,6 +109,8 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         ~RequireTagClassAttributeEnforcer()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+
             Utilities.Unregister(this);
 
             Unsubscribe();
@@ -117,10 +122,15 @@ namespace Ikonoclast.ClassAttributes.Editor
 
         private static void Subscribe()
         {
+            if (isSubscribed)
+                return;
+
             EditorSceneManager.sceneOpened += OnSceneOpened;
             Selection.selectionChanged += OnSelectionChanged;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement += OnRequestAttributeEnforcement;
+
+            isSubscribed = true;
         }
 
         private static void Unsubscribe()
@@ -129,6 +139,8 @@ namespace Ikonoclast.ClassAttributes.Editor
             Selection.selectionChanged -= OnSelectionChanged;
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             ClassAttributeEnforcerEditorWindow.RequestAttributeEnforcement -= OnRequestAttributeEnforcement;
+
+            isSubscribed = false;
         }
 
         private static void LoadConfigurations()
@@ -290,6 +302,15 @@ namespace Ikonoclast.ClassAttributes.Editor
             if (enforceOnSceneChange)
             {
                 OnHierarchyChanged();
+            }
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            switch (playModeStateChange)
+            {
+                case PlayModeStateChange.EnteredEditMode: Subscribe(); break;
+                case PlayModeStateChange.EnteredPlayMode: Unsubscribe(); break;
             }
         }
 


### PR DESCRIPTION
- unsubscribe from all enforcement event listeners when the editor enters the play mode
- closes #14 